### PR TITLE
Minimal solution that should solve the main issue we had

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -12,5 +12,5 @@ read_globals = {
 	"dump",
 
 	-- deps
-	"default", "minetest"
+	"default", "minetest", "xp_redo"
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,6 @@
 
 globals = {
+	"afkkick"
 }
 
 read_globals = {

--- a/init.lua
+++ b/init.lua
@@ -5,70 +5,102 @@ To the extent possible under law, the author(s)
 have dedicated all copyright and related and neighboring rights
 to this software to the public domain worldwide. This software is
 distributed without any warranty.
-]]
+--]]
 
-local MAX_INACTIVE_TIME = tonumber(minetest.settings:get("afkkick.max_inactive_time") or "1800")
-local CHECK_INTERVAL = 1
-local WARN_TIME = 20
+afkkick = {}
 
-local players = {}
-local checkTimer = 0
+afkkick.maxInactiveTime = tonumber(minetest.settings:get("afkkick.max_inactive_time") or "1800")
+-- TODO: discuss if these may be useful as server settings
+afkkick.checkInterval = 2
+afkkick.warnTime = 60
+afkkick.radius = 13
+
+afkkick.exemptXP = 100000
+afkkick.hasXPredo = minetest.get_modpath('xp_redo')
+
+-- TODO: make these translatable
+afkkick.kickWarning = "Warning, you have %d seconds to move away from spawn island or be kicked"
+afkkick.kickMessage = "Kicked for loitering at spawn"
+
+-- one time calculation of kickarea
+local spawnPos = minetest.string_to_pos(minetest.settings:get("static_spawnpoint") or "(0, 0, 0)")
+local radiusVector = { x = afkkick.radius, y = afkkick.radius, z = afkkick.radius }
+afkkick.posA = vector.add(spawnPos, radiusVector)
+afkkick.posB = vector.subtract(spawnPos, radiusVector)
+
+-- table tracking players times
+afkkick.players = {}
 
 minetest.register_on_joinplayer(function(player)
 	local playerName = player:get_player_name()
-	players[playerName] = {
-		lastAction = minetest.get_gametime()
+	afkkick.players[playerName] = {
+		kickAt = 0
 	}
 end)
 
 minetest.register_on_leaveplayer(function(player)
 	local playerName = player:get_player_name()
-	players[playerName] = nil
+	afkkick.players[playerName] = nil
 end)
 
-minetest.register_on_chat_message(function(playerName)
-	players[playerName]["lastAction"] = minetest.get_gametime()
-end)
+-- track time of last call
+local iTimeNext = 0
 
-minetest.register_globalstep(function(dtime)
-	local currGameTime = minetest.get_gametime()
+minetest.register_globalstep(function()
 
-	--Check for inactivity once every CHECK_INTERVAL seconds
-	checkTimer = checkTimer + dtime
+	local currentTime = minetest.get_gametime()
 
-	local checkNow = checkTimer >= CHECK_INTERVAL
-	if checkNow then
-		checkTimer = checkTimer - CHECK_INTERVAL
+	-- Check for inactivity once every CHECK_INTERVAL seconds
+	if iTimeNext > currentTime then
+		-- not yet
+		return
 	end
 
-	--Loop through each player in players
-	for playerName, info in pairs(players) do
-		local player = minetest.get_player_by_name(playerName)
-		if player then
-			--Check if this player is doing an action
-			for _, keyPressed in pairs(player:get_player_control()) do
-				if keyPressed then
-					info["lastAction"] = currGameTime
-				end
-			end
+	iTimeNext = currentTime + afkkick.checkInterval
 
-			if checkNow then
-				--Kick player if he/she has been inactive for longer than MAX_INACTIVE_TIME seconds
-				if info["lastAction"] + MAX_INACTIVE_TIME < currGameTime then
-					minetest.kick_player(playerName, "Kicked for inactivity")
-				end
+	local playerPos, playerName
+	local isInX, isInY, isInZ, isAtSpawn
+	local kickTime, warnTime
+	local xp
 
-				--Warn player if he/she has less than WARN_TIME seconds to move or be kicked
-				if info["lastAction"] + MAX_INACTIVE_TIME - WARN_TIME < currGameTime then
-					minetest.chat_send_player(playerName,
-						minetest.colorize("#FF8C00", "Warning, you have " ..
-						tostring(info["lastAction"] + MAX_INACTIVE_TIME - currGameTime + 1) ..
-						" seconds to move or be kicked"))
-				end
+	-- Loop through each player that is online
+	for _, player in ipairs(minetest.get_connected_players()) do
+		playerName = player:get_player_name()
+		-- only bother if is a real player
+		if 0 < #playerName then
+			if afkkick.hasXPredo then
+				xp = xp_redo.get_xp(playerName)
+			else
+				xp = -1
 			end
-		else
-			-- Clean up garbage
-			players[playerName] = nil
-		end
-	end
-end)
+			-- ignore players that have enough XP
+			if xp < afkkick.exemptXP then
+				--Check if this player is near spawn
+				playerPos = player:get_pos()
+				isInX = (playerPos.x > afkkick.posB.x) and (playerPos.x < afkkick.posA.x)
+				isInY = (playerPos.y > afkkick.posB.y) and (playerPos.y < afkkick.posA.y)
+				isInZ = (playerPos.z > afkkick.posB.z) and (playerPos.z < afkkick.posA.z)
+				isAtSpawn = isInX and isInY and isInZ
+				if isAtSpawn then
+					kickTime = afkkick.players[playerName].kickAt
+					warnTime = kickTime - afkkick.warnTime
+					if 0 == kickTime then
+						-- first time we check and player is at spawn
+						players[playerName].kickAt = currentTime + afkkick.maxInactiveTime
+					elseif kickTime < currentTime then
+						-- player has been here long enough, kick
+						minetest.kick_player(playerName, afkkick.kickMessage)
+					elseif warnTime < currentTime then
+						minetest.chat_send_player(playerName,
+							minetest.colorize("#FF8C00",
+								afkkick.kickWarning:format(kickTime - currentTime)))
+					end
+				else
+					-- player is out of kick location
+					afkkick.players[playerName].kickAt = 0
+				end -- if at spawn or not
+			end -- if got XP
+		end -- if real player
+	end -- for loop
+end -- function
+)

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,6 @@
 --[[
 Afk Kick mod for Minetest by GunshipPenguin
+re-written for Pandorabox.io by SwissalpS
 
 To the extent possible under law, the author(s)
 have dedicated all copyright and related and neighboring rights

--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ afkkick = {}
 afkkick.maxInactiveTime = tonumber(minetest.settings:get("afkkick.max_inactive_time") or "1800")
 afkkick.checkInterval = 120
 afkkick.radius = 13
-afkkick.kickMessage = "Kicked for loitering at spawn"
+afkkick.kickMessage = "for loitering at spawn"
 
 -- one time calculation of kickarea
 local spawnPos = minetest.string_to_pos(minetest.settings:get("static_spawnpoint") or "(0, 0, 0)")

--- a/init.lua
+++ b/init.lua
@@ -59,25 +59,25 @@ minetest.register_globalstep(function()
 		playerName = player:get_player_name()
 		-- only bother if is a real player
 		if 0 < #playerName then
-				--Check if this player is near spawn
-				playerPos = player:get_pos()
-				isInX = (playerPos.x > afkkick.posB.x) and (playerPos.x < afkkick.posA.x)
-				isInY = (playerPos.y > afkkick.posB.y) and (playerPos.y < afkkick.posA.y)
-				isInZ = (playerPos.z > afkkick.posB.z) and (playerPos.z < afkkick.posA.z)
-				isAtSpawn = isInX and isInY and isInZ
-				if isAtSpawn then
-					kickTime = afkkick.players[playerName].kickAt
-					if 0 == kickTime then
-						-- first time we check and player is at spawn
-						players[playerName].kickAt = currentTime + afkkick.maxInactiveTime
-					elseif kickTime < currentTime then
-						-- player has been here long enough, kick
-						minetest.kick_player(playerName, afkkick.kickMessage)
-					end
-				else
-					-- player is out of kick location
-					afkkick.players[playerName].kickAt = 0
-				end -- if at spawn or not
+			--Check if this player is near spawn
+			playerPos = player:get_pos()
+			isInX = (playerPos.x > afkkick.posB.x) and (playerPos.x < afkkick.posA.x)
+			isInY = (playerPos.y > afkkick.posB.y) and (playerPos.y < afkkick.posA.y)
+			isInZ = (playerPos.z > afkkick.posB.z) and (playerPos.z < afkkick.posA.z)
+			isAtSpawn = isInX and isInY and isInZ
+			if isAtSpawn then
+				kickTime = afkkick.players[playerName].kickAt
+				if 0 == kickTime then
+					-- first time we check and player is at spawn
+					afkkick.players[playerName].kickAt = currentTime + afkkick.maxInactiveTime
+				elseif kickTime < currentTime then
+					-- player has been here long enough, kick
+					minetest.kick_player(playerName, afkkick.kickMessage)
+				end
+			else
+				-- player is out of kick location
+				afkkick.players[playerName].kickAt = 0
+			end -- if at spawn or not
 		end -- if real player
 	end -- for loop
 end -- function

--- a/init.lua
+++ b/init.lua
@@ -10,16 +10,8 @@ distributed without any warranty.
 afkkick = {}
 
 afkkick.maxInactiveTime = tonumber(minetest.settings:get("afkkick.max_inactive_time") or "1800")
--- TODO: discuss if these may be useful as server settings
-afkkick.checkInterval = 2
-afkkick.warnTime = 60
+afkkick.checkInterval = 120
 afkkick.radius = 13
-
-afkkick.exemptXP = 100000
-afkkick.hasXPredo = minetest.get_modpath('xp_redo')
-
--- TODO: make these translatable
-afkkick.kickWarning = "Warning, you have %d seconds to move away from spawn island or be kicked"
 afkkick.kickMessage = "Kicked for loitering at spawn"
 
 -- one time calculation of kickarea
@@ -60,21 +52,13 @@ minetest.register_globalstep(function()
 
 	local playerPos, playerName
 	local isInX, isInY, isInZ, isAtSpawn
-	local kickTime, warnTime
-	local xp
+	local kickTime
 
 	-- Loop through each player that is online
 	for _, player in ipairs(minetest.get_connected_players()) do
 		playerName = player:get_player_name()
 		-- only bother if is a real player
 		if 0 < #playerName then
-			if afkkick.hasXPredo then
-				xp = xp_redo.get_xp(playerName)
-			else
-				xp = -1
-			end
-			-- ignore players that have enough XP
-			if xp < afkkick.exemptXP then
 				--Check if this player is near spawn
 				playerPos = player:get_pos()
 				isInX = (playerPos.x > afkkick.posB.x) and (playerPos.x < afkkick.posA.x)
@@ -83,17 +67,12 @@ minetest.register_globalstep(function()
 				isAtSpawn = isInX and isInY and isInZ
 				if isAtSpawn then
 					kickTime = afkkick.players[playerName].kickAt
-					warnTime = kickTime - afkkick.warnTime
 					if 0 == kickTime then
 						-- first time we check and player is at spawn
 						players[playerName].kickAt = currentTime + afkkick.maxInactiveTime
 					elseif kickTime < currentTime then
 						-- player has been here long enough, kick
 						minetest.kick_player(playerName, afkkick.kickMessage)
-					elseif warnTime < currentTime then
-						minetest.chat_send_player(playerName,
-							minetest.colorize("#FF8C00",
-								afkkick.kickWarning:format(kickTime - currentTime)))
 					end
 				else
 					-- player is out of kick location

--- a/init.lua
+++ b/init.lua
@@ -78,7 +78,6 @@ minetest.register_globalstep(function()
 					-- player is out of kick location
 					afkkick.players[playerName].kickAt = 0
 				end -- if at spawn or not
-			end -- if got XP
 		end -- if real player
 	end -- for loop
 end -- function

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
-name = transit_locations
+name = afkkick
 description = kicks players from spawn if they stay there too long.
 depends = default
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,4 @@
 name = transit_locations
 description = kicks players from spawn if they stay there too long.
 depends = default
-optional_depends = xp_redo
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,5 @@
+name = transit_locations
+description = kicks players from spawn if they stay there too long.
+depends = default
+optional_depends = xp_redo
+


### PR DESCRIPTION
every 2 minutes check all players. If they have been standing on central spawn island for more than 30 minutes, kick them without warning. The kick message is clear enough.